### PR TITLE
Redirect input to other file descriptor than stdin

### DIFF
--- a/aliasme.sh
+++ b/aliasme.sh
@@ -57,13 +57,13 @@ _remove() {
 
 _excute() {
     if [ -s ~/.aliasme/cmd ];then
-        while read line; do
+        while read -u9 line; do
             if [ "$1" = "$line" ]; then
-                read line
+                read -u9 line
     			eval $line
     			return 0
             fi
-        done < ~/.aliasme/cmd
+        done 9< ~/.aliasme/cmd
     fi
 	return 1
 }


### PR DESCRIPTION
Incorrect behavior:

![aliasme-error](https://user-images.githubusercontent.com/1418294/88605276-d0112600-d04f-11ea-9941-39d460093b2b.gif)

Correct behavior:

![aliasme-fixed](https://user-images.githubusercontent.com/1418294/88605289-d69f9d80-d04f-11ea-9e39-56bcfb16548c.gif)

I changed the input file descriptor to number 9 to avoid conflict with stdin or other shell internal file descriptors ([see this link](https://linuxize.com/post/how-to-read-a-file-line-by-line-in-bash/#using-file-descriptor)).